### PR TITLE
feature: lambda node 6.10 runtime and sharp 0.17.3

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,6 @@
+machine:
+  node:
+    version: 6.10.1
 test:
   override:
     - mkdir -p $CIRCLE_TEST_REPORTS/reports

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,6 +1,6 @@
 # What is this?
 
-`sharp-0.17.2-linux-x64.tar.gz` was created on a Linux machine. It contains system binaries specific to the [Lambda execution environment](http://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html). This is the same tarball which contains the libvips library binaries if you were to build the sharp module on a Linux machine. We include it here so that it is possible to deploy the lambda function from any OS. The tarball is used during the Serverless deployment/packaging step to create the zip file for deploying the function to Lambda.
+`sharp-0.17.3-aws-lambda-linux-x64-node-6.10.1.tar.gz` was created on a Linux machine. It contains system binaries specific to the [Lambda execution environment](http://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html). This is the same tarball which contains the libvips library binaries if you were to build the sharp module on a Linux machine. We include it here so that it is possible to deploy the lambda function from any OS. The tarball is used during the Serverless deployment/packaging step to create the zip file for deploying the function to Lambda.
 
 We dereference the symlinks when creating the tarball, which means a copy of many linux .so binaries are included in the tarball. We do this because, without the dereference, the symlinks would not be valid on MacOS or Windows systems causing the Serverless packaging step to fail.
 
@@ -8,8 +8,8 @@ To create the Lambda compatible archive, we create an AWS EC2 instance using the
 
 ```bash
 sudo yum install -y gcc-c++ make
-curl --silent --location https://rpm.nodesource.com/setup_4.x | sudo bash -
-sudo yum install nodejs-4.3.2
+curl --silent --location https://rpm.nodesource.com/setup_6.x | sudo bash -
+sudo yum install nodejs-6.10.1
 sudo wget https://dl.yarnpkg.com/rpm/yarn.repo -O /etc/yum.repos.d/yarn.repo
 sudo yum install -y yarn
 ```
@@ -17,9 +17,9 @@ sudo yum install -y yarn
 To create the Sharp tarball:
 
 ```bash
-export SHARP_VERSION=0.17.2
+export SHARP_VERSION=0.17.3
 mkdir sharp-$SHARP_VERSION
 cd sharp-$SHARP_VERSION
 yarn add sharp@$SHARP_VERSION
-tar --no-xattrs --hard-dereference -cznshf sharp-$SHARP_VERSION-linux-x64.tar.gz node_modules
+tar --no-xattrs --hard-dereference -cznshf sharp-$SHARP_VERSION-aws-lambda-linux-x64-node-6.10.1.tar.gz node_modules
 ```

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.1",
   "description": "Serverless-based Lambda function to resize images based on S3 events with the awesome Sharp library",
   "main": "handler.js",
+  "engines": {
+    "node": ">= 6.10.0"
+  },
   "config": {
     "jsSrc": "src/"
   },

--- a/package.json
+++ b/package.json
@@ -48,9 +48,7 @@
     "babel-loader": "^6.4.1",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-polyfill": "^6.23.0",
-    "babel-preset-es2015": "^6.24.0",
-    "babel-preset-es2016": "^6.22.0",
-    "babel-preset-es2017": "^6.22.0",
+    "babel-preset-env": "^1.2.2",
     "babel-preset-stage-3": "^6.22.0",
     "babel-register": "^6.24.0",
     "codacy-coverage": "^2.0.1",
@@ -80,9 +78,14 @@
       "transform-runtime"
     ],
     "presets": [
-      "es2015",
-      "es2016",
-      "es2017",
+      [
+        "env",
+        {
+          "targets": {
+            "node": 6.10
+          }
+        }
+      ],
       "stage-3"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
   },
   "homepage": "https://github.com/adieuadieu/serverless-sharp-image",
   "dependencies": {
-    "aws-sdk": "^2.34.0",
+    "aws-sdk": "^2.36.0",
     "babel-runtime": "^6.23.0",
     "mime-types": "^2.1.15",
-    "sharp": "^0.17.2",
+    "sharp": "^0.17.3",
     "sprintf-js": "1.0.3"
   },
   "devDependencies": {
@@ -54,9 +54,9 @@
     "babel-preset-stage-3": "^6.22.0",
     "babel-register": "^6.24.0",
     "codacy-coverage": "^2.0.1",
-    "coveralls": "^2.12.0",
+    "coveralls": "^2.13.0",
     "decompress": "^4.0.0",
-    "eslint": "^3.18.0",
+    "eslint": "^3.19.0",
     "eslint-config-airbnb-base": "^11.1.2",
     "eslint-plugin-ava": "^4.2.0",
     "eslint-plugin-import": "2.2.0",
@@ -65,7 +65,7 @@
     "fs-extra": "^2.1.2",
     "json-loader": "0.5.4",
     "nyc": "^10.2.0",
-    "serverless": "^1.10.0",
+    "serverless": "^1.10.1",
     "serverless-webpack": "^1.0.0-rc.4",
     "tap-xunit": "^1.7.0",
     "webpack": "1.14.0"

--- a/package.json
+++ b/package.json
@@ -111,11 +111,6 @@
     },
     "rules": {
       "no-console": 0,
-      "max-len": [
-        2,
-        140,
-        2
-      ],
       "semi": [
         "error",
         "never"

--- a/serverless.yml
+++ b/serverless.yml
@@ -2,7 +2,7 @@ service: ${file(config.json):name}
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
   profile: ${file(config.json):provider.profile}
   stage: ${file(config.json):provider.stage}
   region: ${file(config.json):provider.region}

--- a/src/config.test.js
+++ b/src/config.test.js
@@ -43,7 +43,10 @@ test('each output must have an S3 object key defined', (t) => {
 })
 
 test('should be able to read from the configured S3 source bucket', async (t) => {
-  const key = [sourcePrefix, 'totally-fake-made-up-test-key-that-most-likely-does-not-exist.test'].join('/')
+  const key = [
+    sourcePrefix,
+    'totally-fake-made-up-test-key-that-most-likely-does-not-exist.test',
+  ].join('/')
   const promise = get({ Key: key })
 
   const result = await t.throws(promise, 'The specified key does not exist.')
@@ -52,7 +55,10 @@ test('should be able to read from the configured S3 source bucket', async (t) =>
 })
 
 test('should be able to write to the configured S3 destination bucket', async (t) => {
-  const key = [destinationPrefix, 'totally-fake-made-up-test-key-that-most-likely-does-not-exist.test'].join('')
+  const key = [
+    destinationPrefix,
+    'totally-fake-made-up-test-key-that-most-likely-does-not-exist.test',
+  ].join('')
   const promise = upload('test', { Key: key })
 
   await t.notThrows(promise)

--- a/src/image.js
+++ b/src/image.js
@@ -5,12 +5,16 @@ import { makeKey, decodeS3EventKey } from './utils'
 
 const { outputs } = config
 
-export default async function processItem ({ eventName, s3: { object: { key: undecodedKey } } = { object: { key: false } } }) {
+export default (async function processItem (
+  { eventName, s3: { object: { key: undecodedKey } } = { object: { key: false } } },
+) {
   const key = decodeS3EventKey(undecodedKey)
   console.log('Processing: ', key)
 
   if (eventName.split(':')[0] !== 'ObjectCreated') {
-    throw new Error(`Event does not contain a valid type (e.g. ObjectCreated). Invoked by event name: ${eventName}`)
+    throw new Error(
+      `Event does not contain a valid type (e.g. ObjectCreated). Invoked by event name: ${eventName}`,
+    )
   }
 
   if (!key) {
@@ -23,7 +27,6 @@ export default async function processItem ({ eventName, s3: { object: { key: und
 
   return Promise.all(
     streams.map((stream, index) =>
-      upload(stream, { ...outputs[index].params, Key: makeKey(outputs[index].key, context) })
-    )
+      upload(stream, { ...outputs[index].params, Key: makeKey(outputs[index].key, context) })),
   )
-}
+});

--- a/src/image.test.js
+++ b/src/image.test.js
@@ -29,19 +29,17 @@ test.before(() => upload(testImageStream, { Key: testKey }, sourceBucket))
 test.after.always(() => remove([testKey], sourceBucket))
 
 test('processItem()', async (t) => {
-  try {
-    await processItem({ eventName: 'fake-event' })
-    t.fail('Should throw error when event name is invalid.')
-  } catch (error) {
-    t.pass()
-  }
+  await t.throws(
+    processItem({ ...event.Records[0], eventName: 'fake-event' }),
+    Error,
+    'It should throw an Error when not provided with a valid eventName',
+  )
 
-  try {
-    await processItem({ eventName: 'ObjectCreated' })
-    t.fail('Should throw error when S3 object key is missing.')
-  } catch (error) {
-    t.pass()
-  }
+  await t.throws(
+    processItem({ eventName: 'ObjectCreated' }),
+    Error,
+    'It should throw error when S3 object key is missing.',
+  )
 
   const promise = processItem(event.Records[0])
   t.notThrows(promise)

--- a/src/image.test.js
+++ b/src/image.test.js
@@ -48,7 +48,11 @@ test('processItem()', async (t) => {
 
   const result = await promise
 
-  t.is(result.length, outputs.length, 'Number of objects uploaded to S3 should match the number of outputs defined in config.')
+  t.is(
+    result.length,
+    outputs.length,
+    'Number of objects uploaded to S3 should match the number of outputs defined in config.',
+  )
 
   // Teardown. Remove the resized images from the S3 bucket.
   await remove(result.map(({ Key }) => Key), destinationBucket)

--- a/src/sharp.js
+++ b/src/sharp.js
@@ -2,7 +2,7 @@ import sharp from 'sharp'
 
 const options = { all: [], outputs: [] }
 
-export default async function sharpify (input, { all, outputs } = options, toBuffer = false) {
+export default (async function sharpify (input, { all, outputs } = options, toBuffer = false) {
   const image = sharp(input)
 
   /* preOperations are performed on the input image and shared across all the outputs */
@@ -15,6 +15,6 @@ export default async function sharpify (input, { all, outputs } = options, toBuf
 
       operations.forEach(([func, ...parameters]) => clone[func](...parameters))
       return toBuffer ? clone.toBuffer() : clone
-    })
+    }),
   )
-}
+});

--- a/src/sharp.test.js
+++ b/src/sharp.test.js
@@ -6,20 +6,13 @@ import sharpify from './sharp'
 const testImage = path.join(__dirname, 'test image.jpg')
 
 const options = {
-  all: [
-    ['toFormat', 'webp', { quality: 80 }],
-    ['rotate', 90],
-  ],
+  all: [['toFormat', 'webp', { quality: 80 }], ['rotate', 90]],
   outputs: [
     {
-      operations: [
-        ['resize', 100, 200],
-      ],
+      operations: [['resize', 100, 200]],
     },
     {
-      operations: [
-        ['resize', 200, 100],
-      ],
+      operations: [['resize', 200, 100]],
     },
   ],
 }
@@ -29,15 +22,21 @@ const { all, outputs } = options
 test('process input image based on configuration options', async (t) => {
   const images = await sharpify(testImage, options, true)
 
-  t.is(images.length, outputs.length, 'number of images should match the number of defined outputs')
+  t.is(
+    images.length,
+    outputs.length,
+    'number of images should match the number of defined outputs',
+  )
 
-  await Promise.all(images.map(async (image, index) => {
-    const { operations } = outputs[index]
-    const { width, height, format } = await sharp(image).metadata()
+  await Promise.all(
+    images.map(async (image, index) => {
+      const { operations } = outputs[index]
+      const { width, height, format } = await sharp(image).metadata()
 
-    t.is(width, operations[0][1], 'image width should match height of defined output')
-    t.is(height, operations[0][2], 'image height should match width of defined output')
+      t.is(width, operations[0][1], 'image width should match height of defined output')
+      t.is(height, operations[0][2], 'image height should match width of defined output')
 
-    t.is(format, all[0][1], 'image format should match format defined for all images')
-  }))
+      t.is(format, all[0][1], 'image format should match format defined for all images')
+    }),
+  )
 })

--- a/src/sharp.test.js
+++ b/src/sharp.test.js
@@ -20,16 +20,24 @@ const options = {
 const { all, outputs } = options
 
 test('process input image based on configuration options', async (t) => {
-  const images = await sharpify(testImage, options, true)
+  t.notThrows(async () => {
+    await sharpify(undefined, undefined, undefined)
+  })
+
+  const imageStreams = await sharpify(testImage, options, false)
+  const imageBuffers = await sharpify(testImage, options, true)
+
+  t.true(imageStreams[0] instanceof sharp)
+  t.true(imageBuffers[0] instanceof Buffer)
 
   t.is(
-    images.length,
+    imageBuffers.length,
     outputs.length,
     'number of images should match the number of defined outputs',
   )
 
   await Promise.all(
-    images.map(async (image, index) => {
+    imageBuffers.map(async (image, index) => {
       const { operations } = outputs[index]
       const { width, height, format } = await sharp(image).metadata()
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -19,6 +19,6 @@ export function makeKey (template = '%(key)', context = {}) {
   return `${destinationPrefix}${sprintf(template, values)}`
 }
 
-export function decodeS3EventKey (key = '') {
-  return decodeURIComponent(key.replace(/\+/g, ' '))
+export function decodeS3EventKey (key) {
+  return key && key.length ? decodeURIComponent(key.replace(/\+/g, ' ')) : key
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,7 +4,11 @@ import config from './config'
 
 const { destinationPrefix } = config
 
-export function makeKey (template = '%(key)', context = {}) {
+export function makeKey (template, context) {
+  if (!template || !context) {
+    throw new Error('makeKey requires both a template string and a context')
+  }
+
   const crumbs = context.key.split('/')
   const directory = crumbs.slice(0, crumbs.length - 1).join('/')
   const filename = crumbs[crumbs.length - 1].split('.')[0]

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -9,9 +9,12 @@ test('makeKey()', (t) => {
   const context = { key: 'test1/test2/test3/fancy.png', type: 'image/jpeg' }
   const expected = `${destinationPrefix}magical/unicorns/test1/test2/test3/test2/fancy.jpeg`
 
-  const key = makeKey(template, context)
-
-  t.is(key, expected)
+  t.is(makeKey(template, context), expected)
+  t.throws(
+    () => makeKey(undefined, undefined),
+    Error,
+    'It should throw an Error if neither template or context are provided.',
+  )
 })
 
 test('decodeS3EventKey()', (t) => {

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -20,4 +20,5 @@ test('decodeS3EventKey()', (t) => {
   const decoded = decodeS3EventKey(undecoded)
 
   t.is(decoded, expected)
+  t.notThrows(() => decodeS3EventKey(undefined), 'decoding empty string should not throw')
 })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,9 @@ const path = require('path')
 const decompress = require('decompress')
 const webpack = require('webpack')
 
+const sharpTarball = path.join(__dirname, 'lib/sharp-0.17.3-aws-linux-x64-node-6.10.1.tar.gz')
+const webpackDir = path.join(__dirname, '.webpack/')
+
 function ExtractTarballPlugin (archive, to) {
   return {
     apply: (compiler) => {
@@ -37,10 +40,7 @@ module.exports = {
   plugins: [
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.optimize.DedupePlugin(),
-    new webpack.optimize.UglifyJsPlugin({ minimize: true, sourceMap: false, warnings: false }),
-    new ExtractTarballPlugin(
-      path.join(__dirname, 'lib/sharp-0.17.2-linux-x64.tar.gz'),
-      path.join(__dirname, '.webpack/')
-    ),
+    // new webpack.optimize.UglifyJsPlugin({ minimize: true, sourceMap: false, warnings: false }),
+    new ExtractTarballPlugin(sharpTarball, webpackDir),
   ],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -350,23 +350,9 @@ ava@^0.18.2:
     unique-temp-dir "^1.0.0"
     update-notifier "^1.0.0"
 
-aws-sdk@^2.36.0:
+aws-sdk@^2.36.0, aws-sdk@^2.7.13:
   version "2.36.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.36.0.tgz#e13b7abbfef3b4476fe1c646fa7587fd6b4808de"
-  dependencies:
-    buffer "4.9.1"
-    crypto-browserify "1.0.9"
-    jmespath "0.15.0"
-    querystring "0.2.0"
-    sax "1.1.5"
-    url "0.10.3"
-    uuid "3.0.0"
-    xml2js "0.4.15"
-    xmlbuilder "2.6.2"
-
-aws-sdk@^2.7.13:
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.16.0.tgz#c3bf4cac031b5af0db2a0f03e75f59a70ace8ff4"
   dependencies:
     buffer "4.9.1"
     crypto-browserify "1.0.9"
@@ -457,13 +443,13 @@ babel-helper-call-delegate@^6.22.0:
     babel-traverse "^6.22.0"
     babel-types "^6.22.0"
 
-babel-helper-define-map@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-helper-define-map/-/babel-helper-define-map-6.22.0.tgz#9544e9502b2d6dfe7d00ff60e82bd5a7a89e95b7"
+babel-helper-define-map@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-define-map/-/babel-helper-define-map-6.23.0.tgz#1444f960c9691d69a2ced6a205315f8fd00804e7"
   dependencies:
-    babel-helper-function-name "^6.22.0"
+    babel-helper-function-name "^6.23.0"
     babel-runtime "^6.22.0"
-    babel-types "^6.22.0"
+    babel-types "^6.23.0"
     lodash "^4.2.0"
 
 babel-helper-explode-assignable-expression@^6.22.0:
@@ -483,6 +469,16 @@ babel-helper-function-name@^6.22.0:
     babel-template "^6.22.0"
     babel-traverse "^6.22.0"
     babel-types "^6.22.0"
+
+babel-helper-function-name@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-6.23.0.tgz#25742d67175c8903dbe4b6cb9d9e1fcb8dcf23a6"
+  dependencies:
+    babel-helper-get-function-arity "^6.22.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.23.0"
+    babel-traverse "^6.23.0"
+    babel-types "^6.23.0"
 
 babel-helper-get-function-arity@^6.22.0:
   version "6.22.0"
@@ -504,6 +500,13 @@ babel-helper-optimise-call-expression@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
     babel-types "^6.22.0"
+
+babel-helper-optimise-call-expression@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.23.0.tgz#f3ee7eed355b4282138b33d02b78369e470622f5"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.23.0"
 
 babel-helper-regex@^6.22.0:
   version "6.22.0"
@@ -533,6 +536,17 @@ babel-helper-replace-supers@^6.22.0:
     babel-template "^6.22.0"
     babel-traverse "^6.22.0"
     babel-types "^6.22.0"
+
+babel-helper-replace-supers@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-replace-supers/-/babel-helper-replace-supers-6.23.0.tgz#eeaf8ad9b58ec4337ca94223bacdca1f8d9b4bfd"
+  dependencies:
+    babel-helper-optimise-call-expression "^6.23.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.23.0"
+    babel-traverse "^6.23.0"
+    babel-types "^6.23.0"
 
 babel-helpers@^6.23.0:
   version "6.23.0"
@@ -629,29 +643,29 @@ babel-plugin-transform-es2015-block-scoped-functions@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-block-scoping@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.22.0.tgz#00d6e3a0bebdcfe7536b9d653b44a9141e63e47e"
+babel-plugin-transform-es2015-block-scoping@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.23.0.tgz#e48895cf0b375be148cd7c8879b422707a053b51"
   dependencies:
     babel-runtime "^6.22.0"
-    babel-template "^6.22.0"
-    babel-traverse "^6.22.0"
-    babel-types "^6.22.0"
+    babel-template "^6.23.0"
+    babel-traverse "^6.23.0"
+    babel-types "^6.23.0"
     lodash "^4.2.0"
 
-babel-plugin-transform-es2015-classes@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.22.0.tgz#54d44998fd823d9dca15292324161c331c1b6f14"
+babel-plugin-transform-es2015-classes@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.23.0.tgz#49b53f326202a2fd1b3bbaa5e2edd8a4f78643c1"
   dependencies:
-    babel-helper-define-map "^6.22.0"
-    babel-helper-function-name "^6.22.0"
-    babel-helper-optimise-call-expression "^6.22.0"
-    babel-helper-replace-supers "^6.22.0"
-    babel-messages "^6.22.0"
+    babel-helper-define-map "^6.23.0"
+    babel-helper-function-name "^6.23.0"
+    babel-helper-optimise-call-expression "^6.23.0"
+    babel-helper-replace-supers "^6.23.0"
+    babel-messages "^6.23.0"
     babel-runtime "^6.22.0"
-    babel-template "^6.22.0"
-    babel-traverse "^6.22.0"
-    babel-types "^6.22.0"
+    babel-template "^6.23.0"
+    babel-traverse "^6.23.0"
+    babel-types "^6.23.0"
 
 babel-plugin-transform-es2015-computed-properties@^6.22.0:
   version "6.22.0"
@@ -660,9 +674,15 @@ babel-plugin-transform-es2015-computed-properties@^6.22.0:
     babel-runtime "^6.22.0"
     babel-template "^6.22.0"
 
-babel-plugin-transform-es2015-destructuring@^6.19.0, babel-plugin-transform-es2015-destructuring@^6.22.0:
+babel-plugin-transform-es2015-destructuring@^6.19.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.22.0.tgz#8e0af2f885a0b2cf999d47c4c1dd23ce88cfa4c6"
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-destructuring@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz#997bb1f1ab967f682d2b0876fe358d60e765c56d"
   dependencies:
     babel-runtime "^6.22.0"
 
@@ -673,9 +693,9 @@ babel-plugin-transform-es2015-duplicate-keys@^6.22.0:
     babel-runtime "^6.22.0"
     babel-types "^6.22.0"
 
-babel-plugin-transform-es2015-for-of@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.22.0.tgz#180467ad63aeea592a1caeee4bf1c8b3e2616265"
+babel-plugin-transform-es2015-for-of@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz#f47c95b2b613df1d3ecc2fdb7573623c75248691"
   dependencies:
     babel-runtime "^6.22.0"
 
@@ -693,7 +713,7 @@ babel-plugin-transform-es2015-literals@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-modules-amd@^6.24.0:
+babel-plugin-transform-es2015-modules-amd@^6.22.0, babel-plugin-transform-es2015-modules-amd@^6.24.0:
   version "6.24.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.0.tgz#a1911fb9b7ec7e05a43a63c5995007557bcf6a2e"
   dependencies:
@@ -701,7 +721,7 @@ babel-plugin-transform-es2015-modules-amd@^6.24.0:
     babel-runtime "^6.22.0"
     babel-template "^6.22.0"
 
-babel-plugin-transform-es2015-modules-commonjs@^6.18.0, babel-plugin-transform-es2015-modules-commonjs@^6.24.0:
+babel-plugin-transform-es2015-modules-commonjs@^6.18.0, babel-plugin-transform-es2015-modules-commonjs@^6.23.0, babel-plugin-transform-es2015-modules-commonjs@^6.24.0:
   version "6.24.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.0.tgz#e921aefb72c2cc26cb03d107626156413222134f"
   dependencies:
@@ -710,15 +730,15 @@ babel-plugin-transform-es2015-modules-commonjs@^6.18.0, babel-plugin-transform-e
     babel-template "^6.23.0"
     babel-types "^6.23.0"
 
-babel-plugin-transform-es2015-modules-systemjs@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.22.0.tgz#810cd0cd025a08383b84236b92c6e31f88e644ad"
+babel-plugin-transform-es2015-modules-systemjs@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.23.0.tgz#ae3469227ffac39b0310d90fec73bfdc4f6317b0"
   dependencies:
     babel-helper-hoist-variables "^6.22.0"
     babel-runtime "^6.22.0"
-    babel-template "^6.22.0"
+    babel-template "^6.23.0"
 
-babel-plugin-transform-es2015-modules-umd@^6.24.0:
+babel-plugin-transform-es2015-modules-umd@^6.23.0:
   version "6.24.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.0.tgz#fd5fa63521cae8d273927c3958afd7c067733450"
   dependencies:
@@ -733,7 +753,7 @@ babel-plugin-transform-es2015-object-super@^6.22.0:
     babel-helper-replace-supers "^6.22.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-parameters@^6.21.0, babel-plugin-transform-es2015-parameters@^6.22.0:
+babel-plugin-transform-es2015-parameters@^6.21.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.22.0.tgz#57076069232019094f27da8c68bb7162fe208dbb"
   dependencies:
@@ -743,6 +763,17 @@ babel-plugin-transform-es2015-parameters@^6.21.0, babel-plugin-transform-es2015-
     babel-template "^6.22.0"
     babel-traverse "^6.22.0"
     babel-types "^6.22.0"
+
+babel-plugin-transform-es2015-parameters@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.23.0.tgz#3a2aabb70c8af945d5ce386f1a4250625a83ae3b"
+  dependencies:
+    babel-helper-call-delegate "^6.22.0"
+    babel-helper-get-function-arity "^6.22.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.23.0"
+    babel-traverse "^6.23.0"
+    babel-types "^6.23.0"
 
 babel-plugin-transform-es2015-shorthand-properties@^6.22.0:
   version "6.22.0"
@@ -771,9 +802,9 @@ babel-plugin-transform-es2015-template-literals@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-typeof-symbol@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.22.0.tgz#87faf2336d3b6a97f68c4d906b0cd0edeae676e1"
+babel-plugin-transform-es2015-typeof-symbol@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz#dec09f1cddff94b52ac73d505c84df59dcceb372"
   dependencies:
     babel-runtime "^6.22.0"
 
@@ -827,47 +858,39 @@ babel-polyfill@^6.23.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-preset-es2015@^6.24.0:
-  version "6.24.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.24.0.tgz#c162d68b1932696e036cd3110dc1ccd303d2673a"
+babel-preset-env@^1.2.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.3.2.tgz#08eabd2bf810c3678069f7e052323419f1448749"
   dependencies:
     babel-plugin-check-es2015-constants "^6.22.0"
+    babel-plugin-syntax-trailing-function-commas "^6.22.0"
+    babel-plugin-transform-async-to-generator "^6.22.0"
     babel-plugin-transform-es2015-arrow-functions "^6.22.0"
     babel-plugin-transform-es2015-block-scoped-functions "^6.22.0"
-    babel-plugin-transform-es2015-block-scoping "^6.22.0"
-    babel-plugin-transform-es2015-classes "^6.22.0"
+    babel-plugin-transform-es2015-block-scoping "^6.23.0"
+    babel-plugin-transform-es2015-classes "^6.23.0"
     babel-plugin-transform-es2015-computed-properties "^6.22.0"
-    babel-plugin-transform-es2015-destructuring "^6.22.0"
+    babel-plugin-transform-es2015-destructuring "^6.23.0"
     babel-plugin-transform-es2015-duplicate-keys "^6.22.0"
-    babel-plugin-transform-es2015-for-of "^6.22.0"
+    babel-plugin-transform-es2015-for-of "^6.23.0"
     babel-plugin-transform-es2015-function-name "^6.22.0"
     babel-plugin-transform-es2015-literals "^6.22.0"
-    babel-plugin-transform-es2015-modules-amd "^6.24.0"
-    babel-plugin-transform-es2015-modules-commonjs "^6.24.0"
-    babel-plugin-transform-es2015-modules-systemjs "^6.22.0"
-    babel-plugin-transform-es2015-modules-umd "^6.24.0"
+    babel-plugin-transform-es2015-modules-amd "^6.22.0"
+    babel-plugin-transform-es2015-modules-commonjs "^6.23.0"
+    babel-plugin-transform-es2015-modules-systemjs "^6.23.0"
+    babel-plugin-transform-es2015-modules-umd "^6.23.0"
     babel-plugin-transform-es2015-object-super "^6.22.0"
-    babel-plugin-transform-es2015-parameters "^6.22.0"
+    babel-plugin-transform-es2015-parameters "^6.23.0"
     babel-plugin-transform-es2015-shorthand-properties "^6.22.0"
     babel-plugin-transform-es2015-spread "^6.22.0"
     babel-plugin-transform-es2015-sticky-regex "^6.22.0"
     babel-plugin-transform-es2015-template-literals "^6.22.0"
-    babel-plugin-transform-es2015-typeof-symbol "^6.22.0"
+    babel-plugin-transform-es2015-typeof-symbol "^6.23.0"
     babel-plugin-transform-es2015-unicode-regex "^6.22.0"
-    babel-plugin-transform-regenerator "^6.22.0"
-
-babel-preset-es2016@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-es2016/-/babel-preset-es2016-6.22.0.tgz#b061aaa3983d40c9fbacfa3743b5df37f336156c"
-  dependencies:
     babel-plugin-transform-exponentiation-operator "^6.22.0"
-
-babel-preset-es2017@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-es2017/-/babel-preset-es2017-6.22.0.tgz#de2f9da5a30c50d293fb54a0ba15d6ddc573f0f2"
-  dependencies:
-    babel-plugin-syntax-trailing-function-commas "^6.22.0"
-    babel-plugin-transform-async-to-generator "^6.22.0"
+    babel-plugin-transform-regenerator "^6.22.0"
+    browserslist "^1.4.0"
+    invariant "^2.2.2"
 
 babel-preset-stage-3@^6.22.0:
   version "6.22.0"
@@ -1047,6 +1070,13 @@ browserify-zlib@^0.1.4:
   dependencies:
     pako "~0.2.0"
 
+browserslist@^1.4.0:
+  version "1.7.7"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-1.7.7.tgz#0bd76704258be829b2398bb50e4b62d1a166b0b9"
+  dependencies:
+    caniuse-db "^1.0.30000639"
+    electron-to-chromium "^1.2.7"
+
 buf-compare@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buf-compare/-/buf-compare-1.0.1.tgz#fef28da8b8113a0a0db4430b0b6467b69730b34a"
@@ -1136,6 +1166,10 @@ camelcase@^2.0.0, camelcase@^2.1.0:
 camelcase@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
+
+caniuse-db@^1.0.30000639:
+  version "1.0.30000646"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000646.tgz#c724b90d61df24286e015fc528d062073c00def4"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -1710,6 +1744,10 @@ ecc-jsbn@~0.1.1:
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+
+electron-to-chromium@^1.2.7:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.2.tgz#b8ce5c93b308db0e92f6d0435c46ddec8f6363ab"
 
 emojis-list@^2.0.0:
   version "2.1.0"
@@ -2627,7 +2665,7 @@ interpret@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.1.tgz#d579fb7f693b858004947af39fa0db49f795602c"
 
-invariant@^2.2.0:
+invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -350,9 +350,9 @@ ava@^0.18.2:
     unique-temp-dir "^1.0.0"
     update-notifier "^1.0.0"
 
-aws-sdk@^2.34.0:
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.34.0.tgz#bf96fb617aa0e1d8728760ca7f00d46d0d9c685c"
+aws-sdk@^2.36.0:
+  version "2.36.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.36.0.tgz#e13b7abbfef3b4476fe1c646fa7587fd6b4808de"
   dependencies:
     buffer "4.9.1"
     crypto-browserify "1.0.9"
@@ -1440,9 +1440,9 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-coveralls@^2.12.0:
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-2.12.0.tgz#b3d064108e29728385b56e42fc2d119f43e0e517"
+coveralls@^2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-2.13.0.tgz#df933876e8c6f478efb04f4d3ab70dc96b7e5a8e"
   dependencies:
     js-yaml "3.6.1"
     lcov-parse "0.0.10"
@@ -1894,9 +1894,9 @@ eslint-tap@^2.0.0:
   dependencies:
     yamlish "0.0.7"
 
-eslint@^3.18.0:
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.18.0.tgz#647e985c4ae71502d20ac62c109f66d5104c8a4b"
+eslint@^3.19.0:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"
   dependencies:
     babel-code-frame "^6.16.0"
     chalk "^1.1.3"
@@ -4263,9 +4263,9 @@ serverless-webpack@^1.0.0-rc.4:
     npm-programmatic "0.0.5"
     webpack "^1.13.1"
 
-serverless@^1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/serverless/-/serverless-1.10.0.tgz#3039360a7513766dda991bf3b08d27227984c530"
+serverless@^1.10.1:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/serverless/-/serverless-1.10.1.tgz#55f0e43664331c45f51108089b2b271a17a55e22"
   dependencies:
     archiver "^1.1.0"
     async "^1.5.2"
@@ -4285,6 +4285,7 @@ serverless@^1.10.0:
     moment "^2.13.0"
     node-fetch "^1.5.3"
     replaceall "^0.1.6"
+    resolve-from "^2.0.0"
     semver "^5.0.3"
     semver-regex "^1.0.0"
     shelljs "^0.6.0"
@@ -4311,9 +4312,9 @@ sha.js@2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.2.6.tgz#17ddeddc5f722fb66501658895461977867315ba"
 
-sharp@^0.17.2:
-  version "0.17.2"
-  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.17.2.tgz#3e5e02c27de10a65927b009d29f2f61920d51f81"
+sharp@^0.17.3:
+  version "0.17.3"
+  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.17.3.tgz#484cd2a70c900370948dcc43e165f78306bff48a"
   dependencies:
     caw "^2.0.0"
     color "^1.0.3"


### PR DESCRIPTION
Kind of feature... kind of chore.

Updates the Lambda runtime to node 6.10 and includes bundle of latest Sharp 0.17.3 compiled for Lambda.

Also switches to using babel-preset-env for configuring babel transpilation, targeting node 6.10.

Also includes some small code style tweaking (reducing the max line length of 140 to something more standard.)